### PR TITLE
Small logic fix when checking private key location

### DIFF
--- a/src/condor_credmon
+++ b/src/condor_credmon
@@ -113,7 +113,7 @@ class CredentialMonitor(object):
         self.schedd = False
         if htcondor != None:
             self._private_key_location = htcondor.param.get('SCITOKEN_PRIVATE_KEY', None)
-            if self._private_key_location != None or os.path.exists(self._private_key_location):
+            if self._private_key_location != None and os.path.exists(self._private_key_location):
                 with open(self._private_key_location, 'r') as private_key:
                     self._private_key = private_key.read()
                 self._private_key_id = htcondor.param['SCITOKEN_PRIVATE_KEY_ID']


### PR DESCRIPTION
Using `or` means that the user may end up running `os.path.exists(None)` which raises an exception. I think `and` is the proper operator here as we both require the value to be provided by the condor config and for the path to exist.